### PR TITLE
adding more task markers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import "@logseq/libs";
 import dayjs from "dayjs";
 import { getDateForPage } from "logseq-dateutils";
 
-const TASK_MARKERS = new Set(["DONE", "NOW", "LATER"]);
+const TASK_MARKERS = new Set(["DONE", "NOW", "LATER", "DOING", "TODO", "WAITING"]);
 
 function main() {
   logseq.DB.onChanged(async (e) => {
@@ -61,7 +61,7 @@ function main() {
         return;
       }
       await logseq.Editor.insertBlock(blockHeader.uuid, query);
-      await logseq.Editor.insertBlock(blockHeader.uuid, '---', {sibling: true})
+      await logseq.Editor.insertBlock(blockHeader.uuid, '---', { sibling: true })
     }
   );
 }


### PR DESCRIPTION
Hey! 

This PR should resolve #5 

By adding more task markers, the `else` statement on line 30 functions and removes the `completed::` property when the task transitions back to `TODO`.

![CleanShot 2023-01-16 at 12 22 01](https://user-images.githubusercontent.com/29644050/212737013-612ee219-3569-470b-88ef-fefe0d744408.gif)
